### PR TITLE
fix: Add CodeArtifact access to Gradle PR analysis

### DIFF
--- a/.github/workflows/pr-analysis-gradle.yml
+++ b/.github/workflows/pr-analysis-gradle.yml
@@ -6,6 +6,12 @@ permissions:
 on:
   workflow_call:
     secrets:
+      codeartifact-username:
+        description: The username to access the codeartifact repository.
+        required: false
+      codeartifact-password:
+        description: The password to access the codeartifact repository.
+        required: false
       sonar-token:
         description: A token allowing access to SonarCloud.
         required: true
@@ -37,6 +43,30 @@ jobs :
           cache: gradle
           distribution: adopt
           java-version: 11
+
+      - name: Check for codeartifact secrets
+        id: check-codeartifact-secrets
+        env:
+          USERNAME: ${{ secrets.codeartifact-username }}
+          PASSWORD: ${{ secrets.codeartifact-password }}
+        run: |
+          if [[ $USERNAME != "" && $PASSWORD != "" ]]; then
+            echo ::set-output name=do-codeartifact-login::true
+          else
+            echo ::set-output name=do-codeartifact-login::false
+          fi
+
+      - name: Configure AWS credentials
+        if: steps.check-codeartifact-secrets.outputs.do-codeartifact-login == 'true'
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.codeartifact-username }}
+          aws-secret-access-key: ${{ secrets.codeartifact-password }}
+          aws-region: eu-west-1
+
+      - name: Add CodeArtifact env var
+        if: steps.check-codeartifact-secrets.outputs.do-codeartifact-login == 'true'
+        run: echo "CODEARTIFACT_AUTH_TOKEN=$(aws codeartifact get-authorization-token --domain hee --domain-owner 430723991443 --query authorizationToken --output text)" >> $GITHUB_ENV
 
       - name: Build
         run: ./gradlew build

--- a/workflow-templates/pr-analysis-gradle.yml
+++ b/workflow-templates/pr-analysis-gradle.yml
@@ -11,3 +11,5 @@ jobs:
     uses: health-education-england/.github/.github/workflows/pr-analysis-gradle.yml@main
     secrets:
       sonar-token: ${{ secrets.SONAR_TOKEN }}
+      codeartifact-username: ${{ secrets.AWS_MAVEN_USERNAME }}
+      codeartifact-password: ${{ secrets.AWS_MAVEN_PASSWORD }}


### PR DESCRIPTION
The Gradle PR analysis workflow does not provide access to our private
CodeArtifact repository, this causes failures in some projects which
require it.
Add the additional steps to get the auth token.

TIS21-2116