### PR TITLE
fix: Mask code artifact token

### DIFF
--- a/.github/workflows/pr-analysis-gradle.yml
+++ b/.github/workflows/pr-analysis-gradle.yml
@@ -66,7 +66,10 @@ jobs :
 
       - name: Add CodeArtifact env var
         if: steps.check-codeartifact-secrets.outputs.do-codeartifact-login == 'true'
-        run: echo "CODEARTIFACT_AUTH_TOKEN=$(aws codeartifact get-authorization-token --domain hee --domain-owner 430723991443 --query authorizationToken --output text)" >> $GITHUB_ENV
+        run: |
+          CODEARTIFACT_AUTH_TOKEN=`aws codeartifact get-authorization-token --domain hee --domain-owner 430723991443 --query authorizationToken --output text --duration-seconds 900`
+          echo CODEARTIFACT_AUTH_TOKEN=$CODEARTIFACT_AUTH_TOKEN >> $GITHUB_ENV
+          echo "::add-mask::$CODEARTIFACT_AUTH_TOKEN"
 
       - name: Build
         run: ./gradlew build

--- a/.github/workflows/pr-analysis-maven.yml
+++ b/.github/workflows/pr-analysis-maven.yml
@@ -54,7 +54,10 @@ jobs :
 
       - name: Add CodeArtifact env var
         if: steps.check-codeartifact-secrets.outputs.do-codeartifact-login == 'true'
-        run: echo "CODEARTIFACT_AUTH_TOKEN=$(aws codeartifact get-authorization-token --domain hee --domain-owner 430723991443 --query authorizationToken --output text)" >> $GITHUB_ENV
+        run: |
+          CODEARTIFACT_AUTH_TOKEN=`aws codeartifact get-authorization-token --domain hee --domain-owner 430723991443 --query authorizationToken --output text --duration-seconds 900`
+          echo CODEARTIFACT_AUTH_TOKEN=$CODEARTIFACT_AUTH_TOKEN >> $GITHUB_ENV
+          echo "::add-mask::$CODEARTIFACT_AUTH_TOKEN"
 
       - name: maven-settings-xml-action
         if: steps.check-codeartifact-secrets.outputs.do-codeartifact-login == 'true'


### PR DESCRIPTION
The code artifact token was logged in plain text, add a masking to the
logging so that it is instead replaced by `***`.

The default duration of the token is 12 hours, we have no need for
tokens to be so long lived so reduce down to the minimum 15 minutes.

NO-TICKET