### PR TITLE
chore: enable maven batch mode

### DIFF
--- a/.github/workflows/pr-analysis-maven.yml
+++ b/.github/workflows/pr-analysis-maven.yml
@@ -67,7 +67,7 @@ jobs :
           repositories: '[{ "id": "hee--Health-Education-England", "url": "https://hee-430723991443.d.codeartifact.eu-west-1.amazonaws.com/maven/Health-Education-England/" }]'
 
       - name: Build
-        run: mvn install
+        run: mvn --batch-mode install
 
       - name: Get modified files
         id: changed-files
@@ -99,4 +99,4 @@ jobs :
         env:
           GITHUB_TOKEN: ${{ github.token }}
           SONAR_TOKEN: ${{ secrets.sonar-token }}
-        run: mvn sonar:sonar
+        run: mvn --batch-mode sonar:sonar


### PR DESCRIPTION
The workflow logs have a large amount of logging caused by Maven not running in batch mode, in particular the progress indication that spams lines like `Progress (1): 4.1/6.8 kB`.
Run maven commands in batch mode so these lines are not logged.

NO-TICKET