### PR TITLE
chore: fix error from modified files step

### DIFF
--- a/.github/workflows/pr-analysis-gradle.yml
+++ b/.github/workflows/pr-analysis-gradle.yml
@@ -76,7 +76,7 @@ jobs :
 
       - name: Get modified files
         id: changed-files
-        uses: jitterbit/get-changed-files@v1
+        uses: Ana06/get-changed-files@v2.1.0
 
       - name: Check modified files
         id: check-files

--- a/.github/workflows/pr-analysis-maven.yml
+++ b/.github/workflows/pr-analysis-maven.yml
@@ -71,7 +71,7 @@ jobs :
 
       - name: Get modified files
         id: changed-files
-        uses: jitterbit/get-changed-files@v1
+        uses: Ana06/get-changed-files@v2.1.0
 
       - name: Check modified files
         id: check-files


### PR DESCRIPTION
The `get-changed-files` Action has an issue which causes the error `The
head commit for this pull_request event is not ahead of the base commit.
Please submit an issue on this action's GitHub repo.` to frequently
occur.
A fork exists which moves this error to a warning to avoid breaking the
workflow.

NO-TICKET