### PR TITLE
chore: migrate from adopt to temurin in workflows

### DIFF
--- a/.github/workflows/pr-analysis-gradle.yml
+++ b/.github/workflows/pr-analysis-gradle.yml
@@ -41,7 +41,7 @@ jobs :
         uses: actions/setup-java@v2.3.1
         with:
           cache: gradle
-          distribution: adopt
+          distribution: temurin
           java-version: 11
 
       - name: Check for codeartifact secrets

--- a/.github/workflows/pr-analysis-maven.yml
+++ b/.github/workflows/pr-analysis-maven.yml
@@ -29,7 +29,7 @@ jobs :
         uses: actions/setup-java@v2.3.1
         with:
           cache: maven
-          distribution: adopt
+          distribution: temurin
           java-version: 11
 
       - name: Check for codeartifact secrets


### PR DESCRIPTION
The AdoptOpenJDK project has moved and rebranded to Adoptium, with
Temurin being the naming of the JDK binaries produced by the Adoptium
project.

TIS21-SHED