### PR TITLE
chore:disable shallow clones for Maven PR

### DIFF
--- a/.github/workflows/pr-analysis-gradle.yml
+++ b/.github/workflows/pr-analysis-gradle.yml
@@ -36,6 +36,8 @@ jobs :
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - name: Set up JDK
         uses: actions/setup-java@v2.3.1

--- a/.github/workflows/pr-analysis-maven.yml
+++ b/.github/workflows/pr-analysis-maven.yml
@@ -24,6 +24,8 @@ jobs :
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - name: Set up JDK
         uses: actions/setup-java@v2.3.1


### PR DESCRIPTION
TIS21-SHED

We got warning in sornarcloud for lots of projects: 
`Shallow clone detected during the analysis. Some files will miss SCM information. This will affect features like auto-assignment of issues. Please configure your build to disable shallow clone.`

According to the setup tutorial (step 2): https://sonarcloud.io/project/configuration?id=Health-Education-England_TIS-SYNC&analysisMode=GitHubActions, we should add `fetch-depth: 0` to disable the shallow clones.