### PR TITLE
fix: use repository name for deploy image

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -54,7 +54,7 @@ jobs :
         with:
           task-definition: ${{ runner.temp }}/task-definition.json
           container-name: ${{ inputs.service-name }}
-          image: ${{ steps.login-ecr.outputs.registry }}/${{ inputs.service-name }}:${{ github.sha }}
+          image: ${{ steps.login-ecr.outputs.registry }}/${{ github.event.repository.name }}:${{ github.sha }}
 
       - name: Deploy Amazon ECS task definition
         uses: aws-actions/amazon-ecs-deploy-task-definition@v1


### PR DESCRIPTION
The image to be inserted in to the task definition should still match the repository name, rather than using the service-name override.

TIS21-3497