### PR TITLE
feat: build stacktrace when rerunning with debug

### DIFF
--- a/.github/workflows/build-gradle.yml
+++ b/.github/workflows/build-gradle.yml
@@ -77,7 +77,7 @@ jobs :
           echo "::add-mask::$CODEARTIFACT_AUTH_TOKEN"
 
       - name: Build
-        run: ./gradlew build
+        run: ./gradlew build ${ACTIONS_RUNNER_DEBUG:+--stacktrace}
 
       - name: Analyse quality
         env:

--- a/.github/workflows/pr-analysis-gradle.yml
+++ b/.github/workflows/pr-analysis-gradle.yml
@@ -75,7 +75,7 @@ jobs:
           echo "::add-mask::$CODEARTIFACT_AUTH_TOKEN"
 
       - name: Build
-        run: ./gradlew build
+        run: ./gradlew build ${ACTIONS_RUNNER_DEBUG:+--stacktrace}
 
       - name: Get modified files
         id: changed-files


### PR DESCRIPTION
Github Actions workflows can be reran with debugging enabled, this adds some additional logging for the GHA steps themselves by setting the `ACTIONS_RUNNER_DEBUG` env var.
Add an experiemental `--stacktrace` flag to see if we can enable stacktraces for Gradle builds based on the presence of the flag.

TIS21-SHED