### PR TITLE
fix: add submodules secret for esr projects

### DIFF
--- a/.github/workflows/build-gradle.yml
+++ b/.github/workflows/build-gradle.yml
@@ -42,6 +42,7 @@ jobs :
         with:
           fetch-depth: 0
           submodules: recursive
+          token: ${{ secrets.GH_REPOS_ALL_READ }}
 
       - name: Set up JDK
         uses: actions/setup-java@v3.10.0

--- a/.github/workflows/pr-analysis-gradle.yml
+++ b/.github/workflows/pr-analysis-gradle.yml
@@ -40,6 +40,7 @@ jobs:
         with:
           fetch-depth: 0
           submodules: recursive
+          token: ${{ secrets.GH_REPOS_ALL_READ }}
 
       - name: Set up JDK
         uses: actions/setup-java@v3.10.0


### PR DESCRIPTION
In order to access the private repos in the submodules we need to use the secrets. A new organisation secret has been created for this purpose.