### PR TITLE
fix: revert submodules command

### DIFF
--- a/.github/workflows/build-gradle.yml
+++ b/.github/workflows/build-gradle.yml
@@ -41,8 +41,6 @@ jobs :
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          submodules: recursive
-          token: ${{ secrets.GH_REPOS_ALL_READ }}
 
       - name: Set up JDK
         uses: actions/setup-java@v3.10.0

--- a/.github/workflows/pr-analysis-gradle.yml
+++ b/.github/workflows/pr-analysis-gradle.yml
@@ -39,8 +39,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          submodules: recursive
-          token: ${{ secrets.GH_REPOS_ALL_READ }}
 
       - name: Set up JDK
         uses: actions/setup-java@v3.10.0


### PR DESCRIPTION
submodules along with its secret are removed as it is not working for ESR and it is also breaking other repos pipelines.
