### PR TITLE
fix: add `id-token: write` permissions

### DIFF
--- a/.github/workflows/build-gradle.yml
+++ b/.github/workflows/build-gradle.yml
@@ -1,5 +1,9 @@
 name: Build
 
+permissions:
+  id-token: write
+  contents: read
+
 on:
   workflow_call:
     secrets:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,5 +1,9 @@
 name: Deploy
 
+permissions:
+  id-token: write
+  contents: read
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/pr-analysis-gradle.yml
+++ b/.github/workflows/pr-analysis-gradle.yml
@@ -1,6 +1,7 @@
 name: PR Analysis
 
 permissions:
+  id-token: write
   pull-requests: write
   contents: read
 

--- a/.github/workflows/pr-analysis-maven.yml
+++ b/.github/workflows/pr-analysis-maven.yml
@@ -1,6 +1,7 @@
 name: PR Analysis
 
 permissions:
+  id-token: write
   pull-requests: write
 
 on:

--- a/workflow-templates/maven-pr-workflow.yml
+++ b/workflow-templates/maven-pr-workflow.yml
@@ -1,5 +1,9 @@
 name: PR Analysis Workflow
 
+permissions:
+  id-token: write
+  contents: read
+
 on:
   pull_request:
   workflow_dispatch:


### PR DESCRIPTION
The `id-token: write` permission is required for requesting the OIDC JWT.

TIS21-4862