### PR TITLE
refactor: make ECR username/password optional

### DIFF
--- a/.github/workflows/build-gradle.yml
+++ b/.github/workflows/build-gradle.yml
@@ -18,10 +18,10 @@ on:
         required: false
       ecr-username:
         description: The username to access the elastic container registry.
-        required: true
+        required: false
       ecr-password:
         description: The username to access the elastic container registry.
-        required: true
+        required: false
       sonar-token:
         description: A token allowing access to SonarCloud.
         required: true

--- a/.github/workflows/ci-cd-gradle.yml
+++ b/.github/workflows/ci-cd-gradle.yml
@@ -21,10 +21,10 @@ on:
         required: false
       ecr-username:
         description: The username to access the elastic container registry.
-        required: true
+        required: false
       ecr-password:
         description: The username to access the elastic container registry.
-        required: true
+        required: false
       sonar-token:
         description: A token allowing access to SonarCloud.
         required: true
@@ -35,8 +35,6 @@ jobs :
     secrets:
       codeartifact-username: ${{ secrets.codeartifact-username }}
       codeartifact-password: ${{ secrets.codeartifact-password }}
-      ecr-username: ${{ secrets.ecr-username }}
-      ecr-password: ${{ secrets.ecr-password }}
       sonar-token: ${{ secrets.sonar-token }}
 
 
@@ -47,9 +45,6 @@ jobs :
       cluster-prefix: ${{ inputs.cluster-prefix }}
       environment: preprod
       service-name: ${{ inputs.service-name}}
-    secrets:
-      ecr-username: ${{ secrets.ecr-username }}
-      ecr-password: ${{ secrets.ecr-password }}
 
   deploy-prod:
     needs: deploy-preprod
@@ -58,6 +53,3 @@ jobs :
       cluster-prefix: ${{ inputs.cluster-prefix }}
       environment: prod
       service-name: ${{ inputs.service-name}}
-    secrets:
-      ecr-username: ${{ secrets.ecr-username }}
-      ecr-password: ${{ secrets.ecr-password }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,10 +26,10 @@ on:
         required: false
       ecr-username:
         description: The username to access the elastic container registry.
-        required: true
+        required: false
       ecr-password:
         description: The username to access the elastic container registry.
-        required: true
+        required: false
 
 jobs :
   deploy:

--- a/workflow-templates/ci-cd-gradle.yml
+++ b/workflow-templates/ci-cd-gradle.yml
@@ -15,6 +15,4 @@ jobs:
     secrets:
       codeartifact-username: ${{ secrets.AWS_MAVEN_USERNAME }}
       codeartifact-password: ${{ secrets.AWS_MAVEN_PASSWORD }}
-      ecr-username: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      ecr-password: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       sonar-token: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
The `ecr-username` and `ecr-password` workflow secrets can not be removed while in use without breaking calling workflows. Make the secrets optional so the calling workflows can be updated without breakages. Once all callers are updated the secrets can be removed from these reusable workflows.

TIS21-4862
TIS21-4948