### PR TITLE
refactor: add `use-codeartifact` flag

### DIFF
--- a/.github/workflows/build-gradle.yml
+++ b/.github/workflows/build-gradle.yml
@@ -6,6 +6,11 @@ permissions:
 
 on:
   workflow_call:
+    inputs:
+      use-codeartifact:
+        description: Whether code artifact should be used to perform the build.
+        required: false
+        type: boolean
     secrets:
       checkout-token:
         description: The token used for performing checkout.
@@ -83,14 +88,14 @@ jobs :
           fi
 
       - name: Configure AWS credentials
-        if: steps.check-codeartifact-secrets.outputs.do-codeartifact-login == 'true'
+        if: inputs.use-codeartifact || steps.check-codeartifact-secrets.outputs.do-codeartifact-login == 'true'
         uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-region: eu-west-1
           role-to-assume: arn:aws:iam::430723991443:role/github-actions-deployer-role
 
       - name: Add CodeArtifact env var
-        if: steps.check-codeartifact-secrets.outputs.do-codeartifact-login == 'true'
+        if: inputs.use-codeartifact || steps.check-codeartifact-secrets.outputs.do-codeartifact-login == 'true'
         run: |
           CODEARTIFACT_AUTH_TOKEN=`aws codeartifact get-authorization-token --domain hee --domain-owner 430723991443 --query authorizationToken --output text --duration-seconds 900`
           echo CODEARTIFACT_AUTH_TOKEN=$CODEARTIFACT_AUTH_TOKEN >> $GITHUB_ENV

--- a/.github/workflows/ci-cd-gradle.yml
+++ b/.github/workflows/ci-cd-gradle.yml
@@ -12,6 +12,10 @@ on:
         required: false
         default: ${{ github.event.repository.name }}
         type: string
+      use-codeartifact:
+        description: Whether code artifact should be used to perform the build.
+        required: false
+        type: boolean
     secrets:
       codeartifact-username:
         description: The username to access the codeartifact repository.
@@ -32,9 +36,9 @@ on:
 jobs :
   build:
     uses: ./.github/workflows/build-gradle.yml
+    with:
+      use-codeartifact: ${{ inputs.use-codeartifact }}
     secrets:
-      codeartifact-username: ${{ secrets.codeartifact-username }}
-      codeartifact-password: ${{ secrets.codeartifact-password }}
       sonar-token: ${{ secrets.sonar-token }}
 
 

--- a/.github/workflows/pr-analysis-gradle.yml
+++ b/.github/workflows/pr-analysis-gradle.yml
@@ -7,6 +7,11 @@ permissions:
 
 on:
   workflow_call:
+    inputs:
+      use-codeartifact:
+        description: Whether code artifact should be used to perform the build.
+        required: false
+        type: boolean
     secrets:
       checkout-token:
         description: The token used for performing checkout.
@@ -79,14 +84,14 @@ jobs:
           fi
 
       - name: Configure AWS credentials
-        if: steps.check-codeartifact-secrets.outputs.do-codeartifact-login == 'true'
+        if: inputs.use-codeartifact || steps.check-codeartifact-secrets.outputs.do-codeartifact-login == 'true'
         uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-region: eu-west-1
           role-to-assume: arn:aws:iam::430723991443:role/github-actions-deployer-role
 
       - name: Add CodeArtifact env var
-        if: steps.check-codeartifact-secrets.outputs.do-codeartifact-login == 'true'
+        if: inputs.use-codeartifact || steps.check-codeartifact-secrets.outputs.do-codeartifact-login == 'true'
         run: |
           CODEARTIFACT_AUTH_TOKEN=`aws codeartifact get-authorization-token --domain hee --domain-owner 430723991443 --query authorizationToken --output text --duration-seconds 900`
           echo CODEARTIFACT_AUTH_TOKEN=$CODEARTIFACT_AUTH_TOKEN >> $GITHUB_ENV

--- a/.github/workflows/pr-analysis-maven.yml
+++ b/.github/workflows/pr-analysis-maven.yml
@@ -6,6 +6,11 @@ permissions:
 
 on:
   workflow_call:
+    inputs:
+      use-codeartifact:
+        description: Whether code artifact should be used to perform the build.
+        required: false
+        type: boolean
     secrets:
       codeartifact-username:
         description: The username to access the codeartifact repository.
@@ -48,14 +53,14 @@ jobs :
           fi
 
       - name: Configure AWS credentials
-        if: steps.check-codeartifact-secrets.outputs.do-codeartifact-login == 'true'
+        if: inputs.use-codeartifact || steps.check-codeartifact-secrets.outputs.do-codeartifact-login == 'true'
         uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-region: eu-west-1
           role-to-assume: arn:aws:iam::430723991443:role/github-actions-deployer-role
 
       - name: Add CodeArtifact env var
-        if: steps.check-codeartifact-secrets.outputs.do-codeartifact-login == 'true'
+        if: inputs.use-codeartifact || steps.check-codeartifact-secrets.outputs.do-codeartifact-login == 'true'
         run: |
           CODEARTIFACT_AUTH_TOKEN=`aws codeartifact get-authorization-token --domain hee --domain-owner 430723991443 --query authorizationToken --output text --duration-seconds 900`
           echo CODEARTIFACT_AUTH_TOKEN=$CODEARTIFACT_AUTH_TOKEN >> $GITHUB_ENV

--- a/workflow-templates/ci-cd-gradle.yml
+++ b/workflow-templates/ci-cd-gradle.yml
@@ -9,10 +9,9 @@ jobs:
   ci-cd:
     name: Build and deploy
     uses: health-education-england/.github/.github/workflows/ci-cd-gradle.yml@main
-    # TODO: add cluster-prefix
-    # with:
-    #   cluster-prefix:
+    with:
+      use-codeartifact: false
+      # TODO: add cluster-prefix
+      # cluster-prefix:
     secrets:
-      codeartifact-username: ${{ secrets.AWS_MAVEN_USERNAME }}
-      codeartifact-password: ${{ secrets.AWS_MAVEN_PASSWORD }}
       sonar-token: ${{ secrets.SONAR_TOKEN }}

--- a/workflow-templates/pr-analysis-gradle.yml
+++ b/workflow-templates/pr-analysis-gradle.yml
@@ -9,7 +9,7 @@ jobs:
   analysis:
     name: Analyse PR
     uses: health-education-england/.github/.github/workflows/pr-analysis-gradle.yml@main
+    with:
+      use-codeartifact: false
     secrets:
       sonar-token: ${{ secrets.SONAR_TOKEN }}
-      codeartifact-username: ${{ secrets.AWS_MAVEN_USERNAME }}
-      codeartifact-password: ${{ secrets.AWS_MAVEN_PASSWORD }}

--- a/workflow-templates/pr-analysis-maven.yml
+++ b/workflow-templates/pr-analysis-maven.yml
@@ -9,7 +9,7 @@ jobs:
   analysis:
     name: Analyse PR
     uses: health-education-england/.github/.github/workflows/pr-analysis-maven.yml@main
+    with:
+      use-codeartifact: false
     secrets:
       sonar-token: ${{ secrets.SONAR_TOKEN }}
-      codeartifact-username: ${{ secrets.AWS_MAVEN_USERNAME }}
-      codeartifact-password: ${{ secrets.AWS_MAVEN_PASSWORD }}


### PR DESCRIPTION
Add a boolean input `use-codeartifact` to replace the codeartifact username and password secrets. The authentication is now done using OIDC so the code artifact user tokens are not required.

The secrets themselves will be removed once all calling workflows have been updated to remove the references.

TIS21-4948
TIS21-4862