### PR TITLE
fix: use `use-codeartifact` input for maven setup

### DIFF
--- a/.github/workflows/pr-analysis-maven.yml
+++ b/.github/workflows/pr-analysis-maven.yml
@@ -67,7 +67,7 @@ jobs :
           echo "::add-mask::$CODEARTIFACT_AUTH_TOKEN"
 
       - name: maven-settings-xml-action
-        if: steps.check-codeartifact-secrets.outputs.do-codeartifact-login == 'true'
+        if: inputs.use-codeartifact || steps.check-codeartifact-secrets.outputs.do-codeartifact-login == 'true'
         uses: whelk-io/maven-settings-xml-action@v21
         with:
           servers: '[{ "id": "hee--Health-Education-England", "username": "aws", "password": "${env.CODEARTIFACT_AUTH_TOKEN}" }]'


### PR DESCRIPTION
TIS21-4862