### PR TITLE
feat: remove redundant ecr and codeartifact secrets

### DIFF
--- a/.github/workflows/build-gradle.yml
+++ b/.github/workflows/build-gradle.yml
@@ -15,18 +15,6 @@ on:
       checkout-token:
         description: The token used for performing checkout.
         required: false
-      codeartifact-username:
-        description: The username to access the codeartifact repository.
-        required: false
-      codeartifact-password:
-        description: The password to access the codeartifact repository.
-        required: false
-      ecr-username:
-        description: The username to access the elastic container registry.
-        required: false
-      ecr-password:
-        description: The username to access the elastic container registry.
-        required: false
       sonar-token:
         description: A token allowing access to SonarCloud.
         required: true
@@ -75,27 +63,15 @@ jobs :
           distribution: temurin
           java-version: 17
 
-      - name: Check for codeartifact secrets
-        id: check-codeartifact-secrets
-        env:
-          USERNAME: ${{ secrets.codeartifact-username }}
-          PASSWORD: ${{ secrets.codeartifact-password }}
-        run: |
-          if [[ $USERNAME != "" && $PASSWORD != "" ]]; then
-            echo "do-codeartifact-login=true" >> $GITHUB_OUTPUT
-          else
-            echo "do-codeartifact-login=false" >> $GITHUB_OUTPUT
-          fi
-
       - name: Configure AWS credentials
-        if: inputs.use-codeartifact || steps.check-codeartifact-secrets.outputs.do-codeartifact-login == 'true'
+        if: inputs.use-codeartifact
         uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-region: eu-west-1
           role-to-assume: arn:aws:iam::430723991443:role/github-actions-deployer-role
 
       - name: Add CodeArtifact env var
-        if: inputs.use-codeartifact || steps.check-codeartifact-secrets.outputs.do-codeartifact-login == 'true'
+        if: inputs.use-codeartifact
         run: |
           CODEARTIFACT_AUTH_TOKEN=`aws codeartifact get-authorization-token --domain hee --domain-owner 430723991443 --query authorizationToken --output text --duration-seconds 900`
           echo CODEARTIFACT_AUTH_TOKEN=$CODEARTIFACT_AUTH_TOKEN >> $GITHUB_ENV

--- a/.github/workflows/ci-cd-gradle.yml
+++ b/.github/workflows/ci-cd-gradle.yml
@@ -17,18 +17,6 @@ on:
         required: false
         type: boolean
     secrets:
-      codeartifact-username:
-        description: The username to access the codeartifact repository.
-        required: false
-      codeartifact-password:
-        description: The password to access the codeartifact repository.
-        required: false
-      ecr-username:
-        description: The username to access the elastic container registry.
-        required: false
-      ecr-password:
-        description: The username to access the elastic container registry.
-        required: false
       sonar-token:
         description: A token allowing access to SonarCloud.
         required: true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,12 +24,6 @@ on:
       checkout-token:
         description: The token used for performing checkout.
         required: false
-      ecr-username:
-        description: The username to access the elastic container registry.
-        required: false
-      ecr-password:
-        description: The username to access the elastic container registry.
-        required: false
 
 jobs :
   deploy:

--- a/.github/workflows/pr-analysis-gradle.yml
+++ b/.github/workflows/pr-analysis-gradle.yml
@@ -16,12 +16,6 @@ on:
       checkout-token:
         description: The token used for performing checkout.
         required: false
-      codeartifact-username:
-        description: The username to access the codeartifact repository.
-        required: false
-      codeartifact-password:
-        description: The password to access the codeartifact repository.
-        required: false
       sonar-token:
         description: A token allowing access to SonarCloud.
         required: true
@@ -71,27 +65,15 @@ jobs:
           distribution: temurin
           java-version: 17
 
-      - name: Check for codeartifact secrets
-        id: check-codeartifact-secrets
-        env:
-          USERNAME: ${{ secrets.codeartifact-username }}
-          PASSWORD: ${{ secrets.codeartifact-password }}
-        run: |
-          if [[ $USERNAME != "" && $PASSWORD != "" ]]; then
-            echo "do-codeartifact-login=true" >> $GITHUB_OUTPUT
-          else
-            echo "do-codeartifact-login=false" >> $GITHUB_OUTPUT
-          fi
-
       - name: Configure AWS credentials
-        if: inputs.use-codeartifact || steps.check-codeartifact-secrets.outputs.do-codeartifact-login == 'true'
+        if: inputs.use-codeartifact
         uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-region: eu-west-1
           role-to-assume: arn:aws:iam::430723991443:role/github-actions-deployer-role
 
       - name: Add CodeArtifact env var
-        if: inputs.use-codeartifact || steps.check-codeartifact-secrets.outputs.do-codeartifact-login == 'true'
+        if: inputs.use-codeartifact
         run: |
           CODEARTIFACT_AUTH_TOKEN=`aws codeartifact get-authorization-token --domain hee --domain-owner 430723991443 --query authorizationToken --output text --duration-seconds 900`
           echo CODEARTIFACT_AUTH_TOKEN=$CODEARTIFACT_AUTH_TOKEN >> $GITHUB_ENV

--- a/.github/workflows/pr-analysis-maven.yml
+++ b/.github/workflows/pr-analysis-maven.yml
@@ -12,12 +12,6 @@ on:
         required: false
         type: boolean
     secrets:
-      codeartifact-username:
-        description: The username to access the codeartifact repository.
-        required: false
-      codeartifact-password:
-        description: The password to access the codeartifact repository.
-        required: false
       sonar-token:
         description: A token allowing access to SonarCloud.
         required: true
@@ -40,34 +34,22 @@ jobs :
           distribution: temurin
           java-version: 11
 
-      - name: Check for codeartifact secrets
-        id: check-codeartifact-secrets
-        env:
-          USERNAME: ${{ secrets.codeartifact-username }}
-          PASSWORD: ${{ secrets.codeartifact-password }}
-        run: |
-          if [[ $USERNAME != "" && $PASSWORD != "" ]]; then
-            echo "do-codeartifact-login=true" >> $GITHUB_OUTPUT
-          else
-            echo "do-codeartifact-login=false" >> $GITHUB_OUTPUT
-          fi
-
       - name: Configure AWS credentials
-        if: inputs.use-codeartifact || steps.check-codeartifact-secrets.outputs.do-codeartifact-login == 'true'
+        if: inputs.use-codeartifact
         uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-region: eu-west-1
           role-to-assume: arn:aws:iam::430723991443:role/github-actions-deployer-role
 
       - name: Add CodeArtifact env var
-        if: inputs.use-codeartifact || steps.check-codeartifact-secrets.outputs.do-codeartifact-login == 'true'
+        if: inputs.use-codeartifact
         run: |
           CODEARTIFACT_AUTH_TOKEN=`aws codeartifact get-authorization-token --domain hee --domain-owner 430723991443 --query authorizationToken --output text --duration-seconds 900`
           echo CODEARTIFACT_AUTH_TOKEN=$CODEARTIFACT_AUTH_TOKEN >> $GITHUB_ENV
           echo "::add-mask::$CODEARTIFACT_AUTH_TOKEN"
 
       - name: maven-settings-xml-action
-        if: inputs.use-codeartifact || steps.check-codeartifact-secrets.outputs.do-codeartifact-login == 'true'
+        if: inputs.use-codeartifact
         uses: whelk-io/maven-settings-xml-action@v21
         with:
           servers: '[{ "id": "hee--Health-Education-England", "username": "aws", "password": "${env.CODEARTIFACT_AUTH_TOKEN}" }]'


### PR DESCRIPTION
All calling workflows have been updated to no longer provide the `ecr-username`, `ecr-password`, `codeartifact-username` or `codeartifact-password` secrets. These can now be removed from all workflows.

TIS21-4947
TIS21-4862