### PR TITLE
fix: getting current branch name

### DIFF
--- a/.github/workflows/clear-runs.yml
+++ b/.github/workflows/clear-runs.yml
@@ -38,7 +38,7 @@ jobs:
                owner: context.repo.owner,
                repo: context.repo.repo,
                workflow_id: ${{ steps.get-workflow-id.outputs.result }},
-               branch: "${GITHUB_REF#refs/*/}",
+               branch: "${{ github.ref_name }}",
                status: "waiting"
             })
             console.log("Get waiting runs response = ", response.data);          


### PR DESCRIPTION
`${GITHUB_REF#refs/*/}` doesn't seem to work in the quote. Fix by getting current branch with `${{ github.ref_name }}` instead