### PR TITLE
fix: passing PAT secret to clear-runs workflow

### DIFF
--- a/.github/workflows/ci-cd-gradle.yml
+++ b/.github/workflows/ci-cd-gradle.yml
@@ -20,8 +20,8 @@ on:
       sonar-token:
         description: A token allowing access to SonarCloud.
         required: true
-      github-token:
-        description: The token used for rejecting runs
+      reject-pat:
+        description: The Personal Access Token (PAT) used for rejecting runs.
         required: false
 
 jobs:
@@ -46,7 +46,7 @@ jobs:
     with:
       environment: prod
     secrets:
-      github-token: ${{ secrets.github-token }}
+      reject-pat: ${{ secrets.reject-pat }}
 
   deploy-prod:
     needs: deploy-preprod

--- a/.github/workflows/ci-cd-gradle.yml
+++ b/.github/workflows/ci-cd-gradle.yml
@@ -20,6 +20,9 @@ on:
       sonar-token:
         description: A token allowing access to SonarCloud.
         required: true
+      github-token:
+        description: The token used for rejecting runs
+        required: false
 
 jobs:
   build:
@@ -42,6 +45,8 @@ jobs:
     uses: ./.github/workflows/clear-runs.yml
     with:
       environment: prod
+    secrets:
+      github-token: ${{ secrets.github-token }}
 
   deploy-prod:
     needs: deploy-preprod

--- a/.github/workflows/clear-runs.yml
+++ b/.github/workflows/clear-runs.yml
@@ -9,7 +9,7 @@ on:
         type: string
     secrets:
       reject-pat:
-        description: The token used for rejecting runs
+        description: The Personal Access Token (PAT) used for rejecting runs.
         required: true
 
 jobs:

--- a/.github/workflows/clear-runs.yml
+++ b/.github/workflows/clear-runs.yml
@@ -8,7 +8,7 @@ on:
         required: false
         type: string
     secrets:
-      github-token:
+      reject-pat:
         description: The token used for rejecting runs
         required: true
 
@@ -82,7 +82,7 @@ jobs:
       - name: Reject previous workflow runs
         uses: actions/github-script@v6
         with:
-          github-token: ${{ secrets.github-token }}
+          github-token: ${{ secrets.reject-pat }}
           script: |
             github.rest.actions.reviewPendingDeploymentsForRun({
                owner: context.repo.owner,

--- a/.github/workflows/clear-runs.yml
+++ b/.github/workflows/clear-runs.yml
@@ -7,6 +7,10 @@ on:
         description: The environment input for deployment approval.
         required: false
         type: string
+    secrets:
+      github-token:
+        description: The token used for rejecting runs
+        required: true
 
 jobs:
   get-previous-runs:
@@ -78,7 +82,7 @@ jobs:
       - name: Reject previous workflow runs
         uses: actions/github-script@v6
         with:
-          github-token: ${{ secrets.PAT_REJECT_APPROVALS }}
+          github-token: ${{ secrets.github-token }}
           script: |
             github.rest.actions.reviewPendingDeploymentsForRun({
                owner: context.repo.owner,


### PR DESCRIPTION
The PAT secret only works in the workflow itself, it need to be passed in when it is called as a reusable workflow.
(All our repo that used `ci-cd-gradle.yml` will need to be updated for adding the secrets)