### PR TITLE
feat: allow overriding the java version

### DIFF
--- a/.github/workflows/build-gradle.yml
+++ b/.github/workflows/build-gradle.yml
@@ -11,6 +11,10 @@ on:
         description: Whether code artifact should be used to perform the build.
         required: false
         type: boolean
+      java-version:
+        default: "17"
+        description: The Java version used in the workflow.
+        type: string
     secrets:
       checkout-token:
         description: The token used for performing checkout.
@@ -19,7 +23,7 @@ on:
         description: A token allowing access to SonarCloud.
         required: true
 
-jobs :
+jobs:
   validate-wrapper:
     name: Validate Gradle wrapper
     runs-on: ubuntu-latest
@@ -61,7 +65,7 @@ jobs :
         with:
           cache: gradle
           distribution: temurin
-          java-version: 17
+          java-version: ${{ inputs.java-version }}
 
       - name: Configure AWS credentials
         if: inputs.use-codeartifact

--- a/.github/workflows/ci-cd-gradle.yml
+++ b/.github/workflows/ci-cd-gradle.yml
@@ -17,7 +17,7 @@ on:
         required: false
         type: boolean
       java-version:
-        default: 17
+        default: "17"
         description: The Java version used in the workflow.
         type: string
     secrets:

--- a/.github/workflows/ci-cd-gradle.yml
+++ b/.github/workflows/ci-cd-gradle.yml
@@ -16,6 +16,10 @@ on:
         description: Whether code artifact should be used to perform the build.
         required: false
         type: boolean
+      java-version:
+        default: 17
+        description: The Java version used in the workflow.
+        type: string
     secrets:
       sonar-token:
         description: A token allowing access to SonarCloud.
@@ -29,6 +33,7 @@ jobs:
     uses: ./.github/workflows/build-gradle.yml
     with:
       use-codeartifact: ${{ inputs.use-codeartifact }}
+      java-version: ${{ inputs.java-version }}
     secrets:
       sonar-token: ${{ secrets.sonar-token }}
 

--- a/.github/workflows/pr-analysis-gradle.yml
+++ b/.github/workflows/pr-analysis-gradle.yml
@@ -12,6 +12,10 @@ on:
         description: Whether code artifact should be used to perform the build.
         required: false
         type: boolean
+      java-version:
+        default: "17"
+        description: The Java version used in the workflow.
+        type: string
     secrets:
       checkout-token:
         description: The token used for performing checkout.
@@ -63,7 +67,7 @@ jobs:
         with:
           cache: gradle
           distribution: temurin
-          java-version: 17
+          java-version: ${{ inputs.java-version }}
 
       - name: Configure AWS credentials
         if: inputs.use-codeartifact


### PR DESCRIPTION
It was tempting to go to a matrix build but walking before running.

I have not done the maven workflows.
Swapping to gradle is as likely to go along with java upgrades.

TIS21-4466: ESR Notification Generator on ECS