### PR TITLE
feat: verify deployed task definition

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -73,9 +73,21 @@ jobs :
           image: ${{ steps.login-ecr.outputs.registry }}/${{ github.event.repository.name }}:${{ github.sha }}
 
       - name: Deploy Amazon ECS task definition
+        id: ecs-deploy
         uses: aws-actions/amazon-ecs-deploy-task-definition@v1
         with:
           task-definition: ${{ steps.task-def.outputs.task-definition }}
           service: ${{ inputs.service-name }}
           cluster: ${{ inputs.cluster-prefix }}-${{ inputs.environment }}
           wait-for-service-stability: true
+
+      - name: Verify ECS deployment
+        run: |
+          CURRENT_TASK_DEF_ARN=$(aws ecs describe-services --cluster ${{ inputs.cluster-prefix }}-${{ inputs.environment }} --service ${{ inputs.service-name }} --query services[0].deployments[0].taskDefinition | jq -r ".")
+          NEW_TASK_DEF_ARN=${{ steps.ecs-deploy.outputs.task-definition-arn }}
+          echo "Current task arn: $CURRENT_TASK_DEF_ARN"
+          echo "New task arn: $NEW_TASK_DEF_ARN"
+          if [ "$CURRENT_TASK_DEF_ARN" != "$NEW_TASK_DEF_ARN" ]; then
+            echo "Deployment failed."
+            exit 1
+          fi


### PR DESCRIPTION
If ECS circuit breaker is enabled for a service the ECS deploy step can give a false successful result, as the triggered rollback is detected as "healthy".

The task definition ARN can be checked against the expectation as a workaround.
See:
https://github.com/aws-actions/amazon-ecs-deploy-task-definition/issues/191

TIS21-4819
TIS21-5327