### PR TITLE
build: fix PR Analysis - Common permissions

### DIFF
--- a/.github/workflows/pr-analysis-common.yml
+++ b/.github/workflows/pr-analysis-common.yml
@@ -1,7 +1,7 @@
 name: PR Analysis - Common
 
 permissions:
-  contents: read
+  pull-requests: read
 
 on:
   workflow_call:
@@ -12,10 +12,5 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4.1.1
-        with:
-          fetch-depth: 0
-
       - name: Lint commits
         uses: wagoid/commitlint-github-action@v5.4.4


### PR DESCRIPTION
The commit linter needs PR read permissions, not content read permissions.

TIS21-SHED