### PR TITLE
chore:bump up java version

### DIFF
--- a/.github/workflows/pr-analysis-maven.yml
+++ b/.github/workflows/pr-analysis-maven.yml
@@ -32,7 +32,7 @@ jobs :
         with:
           cache: maven
           distribution: temurin
-          java-version: 11
+          java-version: 17
 
       - name: Configure AWS credentials
         if: inputs.use-codeartifact


### PR DESCRIPTION
As Sonarcloud's stopped supporting Java 11 since 15 Jan 2024, our new PRs' analysis of Maven project are all blocked. So update Java version is a little urgent.

TIS-SHED