### PR TITLE
feat: return version when auto incrementing

### DIFF
--- a/.github/workflows/auto-version.yml
+++ b/.github/workflows/auto-version.yml
@@ -5,11 +5,18 @@ permissions:
 
 on:
   workflow_call:
+    outputs:
+      new-version:
+        description: The new version after being incremented, or empty if not incremented.
+        value: ${{ jobs.increment-version.outputs.new-version }}
 
 jobs:
   increment-version:
     name: Increment Version
     runs-on: ubuntu-latest
+
+    outputs:
+      new-version: ${{ steps.increment-version.outputs.new_version }}
 
     steps:
       - name: Checkout codebase
@@ -17,18 +24,35 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Verify version increment required
+        id: verify-increment-required
+        run: |
+          if git tag --points-at | grep -Eq 'v[0-9]{1,}.[0-9]{1,}.[0-9]{1,}'; then
+            echo Version tag found on latest commit, increment not required.
+            echo "do_increment=false" >> $GITHUB_OUTPUT
+          else
+            echo Version tag not found on latest commit, increment required.
+            echo "do_increment=true" >> $GITHUB_OUTPUT
+          fi
+
       - name: Get versioning config files
+        if: steps.verify-increment-required.outputs.do_increment == 'true'
         run: |
           config_path=https://raw.githubusercontent.com/health-education-england/.github/main/.github/workflows/auto-version-config
           curl $config_path/.versionrc > .versionrc
           curl $config_path/terraform-version-updater.js > terraform-version-updater.js
 
       - name: Setup Node.js environment
+        if: steps.verify-increment-required.outputs.do_increment == 'true'
         uses: actions/setup-node@v4
 
       - name: Increment version
+        id: increment-version
+        if: steps.verify-increment-required.outputs.do_increment == 'true'
         run: |
           git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
           npx @dwmkerr/standard-version
           git push --follow-tags
+          new_version=`git tag --points-at | grep -Eo '[0-9]{1,}.[0-9]{1,}.[0-9]{1,}'`
+          echo "new_version=$new_version" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Update the auto-version workflow to return the new version after incrementing it.

Also add a check to ensure that the version is only incremented when required, based on a tag in the format `v1.2.3`.

NO-TICKET