### PR TITLE
feat: require PAT for automated versioning

### DIFF
--- a/.github/workflows/auto-version.yml
+++ b/.github/workflows/auto-version.yml
@@ -5,6 +5,10 @@ permissions:
 
 on:
   workflow_call:
+    secrets:
+      commit-pat:
+        description: The Personal Access Token (PAT) used for automated commits.
+        required: true
     outputs:
       new-version:
         description: The new version after being incremented, or empty if not incremented.
@@ -23,6 +27,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ secrets.commit-pat }}
 
       - name: Verify version increment required
         id: verify-increment-required


### PR DESCRIPTION
The auto-version workflow adds a new commit to the main branch, however due to branch protections this is blocked.
Using a PAT with `contents: write` permissions allows the owning user to be configured to ignore the repo's branch protection rules.

NO-TICKET