### PR TITLE
fix: use latest fork for auto versioning

### DIFF
--- a/.github/workflows/auto-version.yml
+++ b/.github/workflows/auto-version.yml
@@ -57,7 +57,7 @@ jobs:
         run: |
           git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
-          npx @dwmkerr/standard-version
+          npx commit-and-tag-version
           git push --follow-tags
           new_version=`git tag --points-at | grep -Eo '[0-9]{1,}.[0-9]{1,}.[0-9]{1,}'`
           echo "new_version=$new_version" >> $GITHUB_OUTPUT


### PR DESCRIPTION
`@dwmkerr/standard-version` has been deprecated and is no longer being updated. `commit-and-tag-version` is a drop-in replacement fork, which also includes several fixes.

NO-TICKET