### PR TITLE
feat: pass build scan flag through CI/CD workflow

### DIFF
--- a/.github/workflows/ci-cd-gradle.yml
+++ b/.github/workflows/ci-cd-gradle.yml
@@ -20,6 +20,10 @@ on:
         default: "17"
         description: The Java version used to build the project
         type: string
+      publish-build-scan:
+        default: false
+        description: Whether a Gradle Build Scan should be published to https://scans.gradle.com
+        type: boolean
     secrets:
       sonar-token:
         description: A token allowing access to SonarCloud.
@@ -34,6 +38,7 @@ jobs:
     with:
       use-codeartifact: ${{ inputs.use-codeartifact }}
       java-version: ${{ inputs.java-version }}
+      publish-build-scan: ${{ publish-build-scan }}
     secrets:
       sonar-token: ${{ secrets.sonar-token }}
 


### PR DESCRIPTION
The Gradle build scan publishing flag was added to `build-gradle.yml`, but most services call the build via `ci-cd-gradle.yml`. Add the `publish-build-scan` flag to the CI/CD workflow and pass it through when calling the build workflow.

NO-TICKET