### PR TITLE
feat: upload build reports for failed PR builds

### DIFF
--- a/.github/workflows/pr-analysis-gradle.yml
+++ b/.github/workflows/pr-analysis-gradle.yml
@@ -84,6 +84,13 @@ jobs:
       - name: Build
         run: ./gradlew build
 
+      - name: Upload build reports on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-reports
+          path: build/reports
+
       - name: Get modified files
         id: changed-files
         uses: Ana06/get-changed-files@v2.3.0


### PR DESCRIPTION
Update the Gradle PR Analysis workflow to upload build reports if the PR fails to build e.g. test failures.

NO-TICKET