### PR TITLE
fix: upgrade java version for sonar

### DIFF
--- a/.github/workflows/build-maven.yml
+++ b/.github/workflows/build-maven.yml
@@ -16,7 +16,7 @@ on:
         description: The Java version used in the workflow.
         type: string
       analysis-java-version:
-        default: "17"
+        default: "21"
         description: The Java version used for analysis.
         type: string
       ecr-repository:

--- a/.github/workflows/pr-analysis-maven.yml
+++ b/.github/workflows/pr-analysis-maven.yml
@@ -95,15 +95,15 @@ jobs :
             Quality analysis was skipped as no source changes were detected.
 
       - name: Set up analysis JDK
-        if: steps.check-files.outputs.do-analysis == 'true' && ${{ inputs.java-version }} < 17
-        uses: actions/setup-java@v4
+        if: steps.check-files.outputs.do-analysis == 'true' && ${{ inputs.java-version }} < 21
+        uses: actions/setup-java@v5
         with:
           cache: maven
           distribution: temurin
-          java-version: 17
+          java-version: 21
 
       - name: maven-settings-xml-action
-        if: steps.check-files.outputs.do-analysis == 'true' && inputs.use-codeartifact && ${{ inputs.java-version }} < 17
+        if: steps.check-files.outputs.do-analysis == 'true' && inputs.use-codeartifact && ${{ inputs.java-version }} < 21
         uses: whelk-io/maven-settings-xml-action@v22
         with:
           servers: '[{ "id": "hee--Health-Education-England", "username": "aws", "password": "${env.CODEARTIFACT_AUTH_TOKEN}" }]'


### PR DESCRIPTION
Sonar Cloud now requires the scanner/runtime used for analysis to run on Java 21 or later. Their Maven scanner documentation lists “Java 21 or later” as a prerequisite, with Java 17 deprecated. Sonar’s general requirements also say Java 17 support for scanner runtimes ends for Sonar Cloud in July 2026.