### PR TITLE
fix: use a JDK compatible with sonar

### DIFF
--- a/.github/workflows/build-gradle.yml
+++ b/.github/workflows/build-gradle.yml
@@ -16,6 +16,7 @@ on:
         description: The Java version used in the workflow.
         type: string
       analysis-java-version:
+        default: "21"
         description: The Java version used for analysis.
         type: string
       publish-build-scan:
@@ -86,14 +87,14 @@ jobs:
         run: ./gradlew build
 
       - name: Set up JDK for analysis
-        if: (inputs.analysis-java-version || inputs.java-version) != inputs.java-version
+        if: inputs.analysis-java-version != inputs.java-version
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: ${{ inputs.analysis-java-version || inputs.java-version }}
+          java-version: ${{ inputs.analysis-java-version }}
 
       - name: Set up Gradle for analysis
-        if: (inputs.analysis-java-version || inputs.java-version) != inputs.java-version
+        if: inputs.analysis-java-version != inputs.java-version
         uses: gradle/actions/setup-gradle@v4
         with:
           build-scan-publish: ${{ inputs.publish-build-scan }}
@@ -117,14 +118,14 @@ jobs:
         uses: aws-actions/amazon-ecr-login@v2
 
       - name: Set up JDK for packaging
-        if: (inputs.analysis-java-version || inputs.java-version) != inputs.java-version
+        if: inputs.analysis-java-version != inputs.java-version
         uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: ${{ inputs.java-version }}
 
       - name: Set up Gradle for packaging
-        if: (inputs.analysis-java-version || inputs.java-version) != inputs.java-version
+        if: inputs.analysis-java-version != inputs.java-version
         uses: gradle/actions/setup-gradle@v4
         with:
           build-scan-publish: ${{ inputs.publish-build-scan }}

--- a/.github/workflows/build-gradle.yml
+++ b/.github/workflows/build-gradle.yml
@@ -15,6 +15,10 @@ on:
         default: "17"
         description: The Java version used in the workflow.
         type: string
+      analysis-java-version:
+        default: "21"
+        description: The Java version used for analysis.
+        type: string
       publish-build-scan:
         default: false
         description: Whether a Gradle Build Scan should be published to https://scans.gradle.com
@@ -81,6 +85,21 @@ jobs:
 
       - name: Build
         run: ./gradlew build
+
+      - name: Set up JDK for analysis
+        if: inputs.analysis-java-version != inputs.java-version
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+
+      - name: Set up Gradle for analysis
+        if: inputs.analysis-java-version != inputs.java-version
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          build-scan-publish: ${{ inputs.publish-build-scan }}
+          build-scan-terms-of-use-url: https://gradle.com/terms-of-service
+          build-scan-terms-of-use-agree: yes
 
       - name: Analyse quality
         env:

--- a/.github/workflows/build-gradle.yml
+++ b/.github/workflows/build-gradle.yml
@@ -91,7 +91,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: inputs.analysis-java-version
+          java-version: ${{ inputs.analysis-java-version }}
 
       - name: Set up Gradle for analysis
         if: inputs.analysis-java-version != inputs.java-version
@@ -122,7 +122,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: inputs.java-version
+          java-version: ${{ inputs.java-version }}
 
       - name: Set up Gradle for packaging
         if: inputs.analysis-java-version != inputs.java-version

--- a/.github/workflows/build-gradle.yml
+++ b/.github/workflows/build-gradle.yml
@@ -91,7 +91,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: 21
+          java-version: inputs.analysis-java-version
 
       - name: Set up Gradle for analysis
         if: inputs.analysis-java-version != inputs.java-version
@@ -116,6 +116,21 @@ jobs:
       - name: Log in to Amazon ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Set up JDK for packaging
+        if: inputs.analysis-java-version != inputs.java-version
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: inputs.java-version
+
+      - name: Set up Gradle for packaging
+        if: inputs.analysis-java-version != inputs.java-version
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          build-scan-publish: ${{ inputs.publish-build-scan }}
+          build-scan-terms-of-use-url: https://gradle.com/terms-of-service
+          build-scan-terms-of-use-agree: yes
 
       - name: Build, tag and push image to Amazon ECR
         env:

--- a/.github/workflows/build-gradle.yml
+++ b/.github/workflows/build-gradle.yml
@@ -16,7 +16,6 @@ on:
         description: The Java version used in the workflow.
         type: string
       analysis-java-version:
-        default: "21"
         description: The Java version used for analysis.
         type: string
       publish-build-scan:
@@ -87,14 +86,14 @@ jobs:
         run: ./gradlew build
 
       - name: Set up JDK for analysis
-        if: inputs.analysis-java-version != inputs.java-version
+        if: (inputs.analysis-java-version || inputs.java-version) != inputs.java-version
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: ${{ inputs.analysis-java-version }}
+          java-version: ${{ inputs.analysis-java-version || inputs.java-version }}
 
       - name: Set up Gradle for analysis
-        if: inputs.analysis-java-version != inputs.java-version
+        if: (inputs.analysis-java-version || inputs.java-version) != inputs.java-version
         uses: gradle/actions/setup-gradle@v4
         with:
           build-scan-publish: ${{ inputs.publish-build-scan }}
@@ -118,14 +117,14 @@ jobs:
         uses: aws-actions/amazon-ecr-login@v2
 
       - name: Set up JDK for packaging
-        if: inputs.analysis-java-version != inputs.java-version
+        if: (inputs.analysis-java-version || inputs.java-version) != inputs.java-version
         uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: ${{ inputs.java-version }}
 
       - name: Set up Gradle for packaging
-        if: inputs.analysis-java-version != inputs.java-version
+        if: (inputs.analysis-java-version || inputs.java-version) != inputs.java-version
         uses: gradle/actions/setup-gradle@v4
         with:
           build-scan-publish: ${{ inputs.publish-build-scan }}

--- a/.github/workflows/unified-build.yml
+++ b/.github/workflows/unified-build.yml
@@ -81,6 +81,7 @@ jobs:
     with:
       use-codeartifact: ${{ inputs.use-codeartifact }}
       java-version: ${{ inputs.java-version }}
+      analysis-java-version: ${{ inputs.analysis-java-version }}
       publish-build-scan: ${{ inputs.publish-build-scan }}
     secrets:
       checkout-token: ${{ secrets.checkout-token }}

--- a/.github/workflows/unified-build.yml
+++ b/.github/workflows/unified-build.yml
@@ -81,7 +81,6 @@ jobs:
     with:
       use-codeartifact: ${{ inputs.use-codeartifact }}
       java-version: ${{ inputs.java-version }}
-      analysis-java-version: ${{ inputs.analysis-java-version }}
       publish-build-scan: ${{ inputs.publish-build-scan }}
     secrets:
       checkout-token: ${{ secrets.checkout-token }}


### PR DESCRIPTION
This follows the pattern used for maven:
An additional input is used rather than specifying the version inline.

TIS21-9030: TCS enum contains additional values